### PR TITLE
chore: スポンサー受付を停止したアカウントをfundingから削除

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,1 @@
-github: [pulsate-dev, m1sk9, laminne]
-
+github: [laminne]


### PR DESCRIPTION
## 概要
- pulsate-devはスポンサー受付を停止しているため削除
- メンバー構成に変更があったため1名削除